### PR TITLE
Fix session_start error message.

### DIFF
--- a/php/courseinfo.tpl.php
+++ b/php/courseinfo.tpl.php
@@ -1,3 +1,9 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+$wwwroot = $CFG->wwwroot;
+?>
+
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -26,12 +32,6 @@
 
 This page displays detailed Information about a course
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-    $wwwroot = $CFG->wwwroot;
-?>
 
 <div id="courseInfo">
     <div class="panel panel-primary">

--- a/php/coursesearch.tpl.php
+++ b/php/coursesearch.tpl.php
@@ -1,3 +1,9 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+$wwwroot = $CFG->wwwroot;
+?>
+
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -27,12 +33,6 @@
 This page lists all courses along with a search box and the option to filter by parent and/or grandparent category.
 Selecting a course will load the courseinfo page.
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-    $wwwroot = $CFG->wwwroot;
-?>
 
 <div id="dashboardCourseSearch">
     <div class="panel panel-info">

--- a/php/courseswithactivities.tpl.php
+++ b/php/courseswithactivities.tpl.php
@@ -1,3 +1,9 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+$wwwroot = $CFG->wwwroot;
+?>
+
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -27,12 +33,6 @@
 This page lists all users with the option of filtering by inactivity.
 Detailed information is shown on the right hand side of the screen after clicking on a user.
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-    $wwwroot = $CFG->wwwroot;
-?>
 
 <div class="panel panel-default" ng-controller="CoursesWithActivitiesController" id="dashboardcourseswithactivities_div">
     <div class="panel-heading">

--- a/php/createnewcourse.tpl.php
+++ b/php/createnewcourse.tpl.php
@@ -1,3 +1,8 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+$wwwroot = $CFG->wwwroot;
+?>
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -26,12 +31,6 @@
 
 This page contains a form to create a new course.
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-    $wwwroot = $CFG->wwwroot;
-?>
 
 <div class="panel panel-default">
     <div class="panel-heading">

--- a/php/emptycourses.tpl.php
+++ b/php/emptycourses.tpl.php
@@ -1,3 +1,9 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+$wwwroot = $CFG->wwwroot;
+?>
+
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -28,12 +34,6 @@ This page lists all empty courses with the option to show detailed information a
 course by clicking on it. The Details will appear on the right half of the screen while the list
 appears on the left half.
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-    $wwwroot = $CFG->wwwroot;
-?>
 
 <div class="panel panel-default">
     <div class="panel-heading">

--- a/php/files.tpl.php
+++ b/php/files.tpl.php
@@ -1,3 +1,8 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+?>
+
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -27,11 +32,6 @@
 This page lists all users with the option of filtering by inactivity.
 Detailed information is shown on the right hand side of the screen after clicking on a user.
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-?>
 
 <div class="panel panel-default" ng-controller="FilesController" id="dashboardFiles">
     <div class="panel-heading">

--- a/php/inactiveusers.tpl.php
+++ b/php/inactiveusers.tpl.php
@@ -1,3 +1,9 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+$wwwroot = $CFG->wwwroot;
+?>
+
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -27,12 +33,6 @@
 This page lists all users with the option of filtering by inactivity.
 Detailed information is shown on the right hand side of the screen after clicking on a user.
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-    $wwwroot = $CFG->wwwroot;
-?>
 
 <div class="panel panel-default">
     <div class="panel-heading">

--- a/php/newusers.tpl.php
+++ b/php/newusers.tpl.php
@@ -1,3 +1,8 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+?>
+
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -27,11 +32,6 @@
 This page lists all new users with the option of filtering by inactivity.
 Detailed information is shown on the right hand side of the screen after clicking on a user.
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-?>
 
 <div class="panel panel-default">
     <div class="panel-heading">

--- a/php/overview.tpl.php
+++ b/php/overview.tpl.php
@@ -1,3 +1,8 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+?>
+
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -33,11 +38,6 @@ on one page.
 
 It will also show an error message if the user is not logged into moodle with the proper rights (at least course creator).
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-?>
 
 <modal title="Error" visible="showModal">
     <form role="form">

--- a/php/urls.tpl.php
+++ b/php/urls.tpl.php
@@ -1,3 +1,8 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+?>
+
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -27,11 +32,6 @@
 This page lists all urls with the option of filtering.
 Detailed information is shown on the right hand side of the screen after clicking on a url.
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-?>
 
 <div class="panel panel-default" ng-controller="URLsController" id="dashboardURLs">
 

--- a/php/userinfo.tpl.php
+++ b/php/userinfo.tpl.php
@@ -1,3 +1,9 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+$wwwroot = $CFG->wwwroot;
+?>
+
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -26,12 +32,6 @@
 
 This page displays detailed Information about a user.
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-    $wwwroot = $CFG->wwwroot;
-?>
 
 <div>
     <div class="panel panel-primary">

--- a/php/usersearch.tpl.php
+++ b/php/usersearch.tpl.php
@@ -1,3 +1,9 @@
+<?php
+require(dirname(__FILE__) . '/../../../config.php');
+require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
+$wwwroot = $CFG->wwwroot;
+?>
+
 <!--
 // This file is part of Moodle - http://moodle.org/
 //
@@ -27,12 +33,6 @@
 This page lists all users with an option to search by string.
 Selecting a user will load the userinfo page.
 -->
-
-<?php
-    require(dirname(__FILE__) . '/../../../config.php');
-    require_capability('report/moodleanalyst:view', \context::instance_by_id(10));
-    $wwwroot = $CFG->wwwroot;
-?>
 
 <div id="dashboardUserSearch">
     <div class="panel panel-info">


### PR DESCRIPTION
Hi,

Tobias's fix #71 was a good call; however, the call to `config.php` came too late. We were getting errors such as: 

> Warning: session_start(): Cannot send session cache limiter - headers already sent (output started at

By moving these PHP statements to the start of the file, i.e. before any output, this error is resolved (see diff).

By the way, the comments at the beginning of the file starting with `<!--` are considered output. You could consider moving these comments into the PHP block, thus reducing output size of all pages. This is not too important though, since only admins can view this :)
